### PR TITLE
Improve some configure checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,9 +29,8 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([CDIO], [libcdio])
 PKG_CHECK_MODULES([CDIO_CDDA], [libcdio_cdda])
 PKG_CHECK_MODULES([CDIO_PARANOIA], [libcdio_paranoia])
-# FIXME: when it will be largely available
-# PKG_CHECK_MODULES([MAGIC], [libmagic])
-AC_CHECK_LIB([magic], [main])
+dnl rely on pkgconfig alone once it is largely available
+AC_CHECK_LIB([magic], [main],, [PKG_CHECK_MODULES([MAGIC], [libmagic])])
 PKG_CHECK_MODULES([NCURSESW], [ncursesw])
 PKG_CHECK_MODULES([SOX], [sox])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ PKG_CHECK_MODULES([XML2], [libxml-2.0])
 PKG_CHECK_MODULES([MAD], [mad])
 PKG_CHECK_MODULES([PULSE], [libpulse])
 PKG_CHECK_MODULES([ASOUND], [alsa])
+AC_CHECK_HEADER(id3tag.h,, [PKG_CHECK_MODULES([ID3TAG], [id3tag])])
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h libintl.h locale.h stdlib.h string.h strings.h \
@@ -130,12 +131,6 @@ AC_CHECK_HEADERS([locale.h])
 AC_CHECK_HEADERS([malloc.h])
 AC_CHECK_HEADERS([stdio_ext.h])
 AC_CHECK_HEADER_STDBOOL
-AC_CHECK_HEADER(id3tag.h, [], [
-        AC_MSG_ERROR([id3tag.h was not found
-*** You must first install libid3tag before you can build this package.
-*** If libid3tag is already installed, you may need to use the CPPFLAGS
-*** environment variable to specify its installed location, e.g. -I<dir>.])
-])
 AC_CHECK_TYPES([ptrdiff_t])
 AC_CHECK_FUNCS([getcwd])
 AC_CHECK_FUNCS([mempcpy])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = $(CDIO_CFLAGS) \
 	$(XML2_CFLAGS) \
 	$(MAD_CFLAGS) \
 	$(PULSE_CFLAGS) \
+	$(ID3TAG_CFLAGS) \
 	$(ASOUND_CFLAGS)
 
 AM_CFLAGS = -I . -D LOCALEDIR=\"$(prefix)/share/locale\"  -Wall -Wextra \
@@ -29,6 +30,7 @@ LIBS += $(CDIO_LIBS) \
 	$(XML2_LIBS) \
 	$(MAD_LIBS) \
 	$(PULSE_LIBS) \
+	$(ID3TAG_LIBS) \
 	$(ASOUND_LIBS)
 
 bin_PROGRAMS = daisy-player


### PR DESCRIPTION
I didn't actually check this beside working on my system (but not fixing anything), yet it should be a bit better by using pkg-config at least as a fallback.

Note that I'm not really sure why libid3tag is a dependency of the root packages, although it only seems to be included in madplay, and even there it doesn't seem to directly use any of its symbols.  I however didn't investigate this further to see whether there was still a reason for this.