### PR TITLE
Remove header from expected result in tests

### DIFF
--- a/tests/Pierre_Rabhi_Vers_la_sobriete_heureuse.expected
+++ b/tests/Pierre_Rabhi_Vers_la_sobriete_heureuse.expected
@@ -1,8 +1,3 @@
-(C)2003-2021 J. Lemmens
-Daisy-player - Version 13.0 
-A parser to play Daisy CD's with Linux
-Scanning for a Daisy CD...
-
 SPINE (61):
    1: Pierre_Rabhi_Vers_la_sobriete_heureuse/speechgen0002.smil#tcp70
    2: Pierre_Rabhi_Vers_la_sobriete_heureuse/speechgen0003.smil#tcp78

--- a/tests/S07241.expected
+++ b/tests/S07241.expected
@@ -1,8 +1,3 @@
-(C)2003-2021 J. Lemmens
-Daisy-player - Version 13.0 
-A parser to play Daisy CD's with Linux
-Scanning for a Daisy CD...
-
 SPINE (42):
    1: S07241/001_Le_Petit_Prince.smil#par_001_Le_Petit_Prince_0_0
    2: S07241/002_Quatrieme_de_couverture.smil#par_002_Quatrieme_de_couverture_0_0

--- a/tests/Six_points_de_lumiere.expected
+++ b/tests/Six_points_de_lumiere.expected
@@ -1,8 +1,3 @@
-(C)2003-2021 J. Lemmens
-Daisy-player - Version 13.0 
-A parser to play Daisy CD's with Linux
-Scanning for a Daisy CD...
-
 SPINE (22):
    1: Six_points_de_lumiere/rjyt0002.smil#rjyt_0001
    2: Six_points_de_lumiere/rjyt0013.smil#rjyt_0012

--- a/tests/Y9621.expected
+++ b/tests/Y9621.expected
@@ -1,8 +1,3 @@
-(C)2003-2021 J. Lemmens
-Daisy-player - Version 13.0 
-A parser to play Daisy CD's with Linux
-Scanning for a Daisy CD...
-
 SPINE (33):
    1: Y9621/wkds0001.smil#aloj_0002
    2: Y9621/wkds0002.smil#aloj_0002

--- a/tests/run1.sh
+++ b/tests/run1.sh
@@ -24,7 +24,14 @@ input="${expected%.*}"
 sed_safe_abs_srcdir=$(printf %s "${abs_srcdir}" | sed 's%[].\[*]%\\\0%g')
 
 # run daisy-player -D
-"$1" -D "$input" | sed "s%${sed_safe_abs_srcdir}%%g;s%/[.]/%%" > "$actual"
+"$1" -D "$input" | sed "
+# strip the header
+1,5d
+# remove the source dir part of the path
+s%${sed_safe_abs_srcdir}%%g
+# sanitize path
+s%/[.]/%%
+" > "$actual"
 
 # compare the result with the expectations
 $generate || diff -u "$expected" "$actual"


### PR DESCRIPTION
This avoids the test results being dependent on the version number and copyright info, which should avoid having to update them upon releases.